### PR TITLE
Fix set instead of merge

### DIFF
--- a/src/redux/reducer.js
+++ b/src/redux/reducer.js
@@ -21,7 +21,7 @@ export default (state = fromJS(initialState), action) => {
     }
     case C.RSM_SAVE_SELECTED: {
       const { id, selected } = action.data;
-      return state.mergeIn([id, 'selected'], selected);
+      return state.setIn([id, 'selected'], selected);
     }
     case C.RSM_REMOVE_SELECT: {
       const { id } = action.data;

--- a/src/redux/reducer.js
+++ b/src/redux/reducer.js
@@ -21,7 +21,7 @@ export default (state = fromJS(initialState), action) => {
     }
     case C.RSM_SAVE_SELECTED: {
       const { id, selected } = action.data;
-      return state.setIn([id, 'selected'], selected);
+      return state.setIn([id, 'selected'], fromJS(selected));
     }
     case C.RSM_REMOVE_SELECT: {
       const { id } = action.data;


### PR DESCRIPTION
#### Description

This branch fixes an issue where you could no remove an option from your multiselect list


----
#### Changes

- Uses `setIn` instead of `mergeIn` for selecting values

----
#### Checklist:
- [ ] Tests – Have you added or edited the test cases?
- [x] Rebase – Has this PR been rebased against `master`?
