### PR TITLE
fix open state for non multiselect

### DIFF
--- a/src/components/SelectConnected.js
+++ b/src/components/SelectConnected.js
@@ -50,7 +50,7 @@ export class SelectConnectedComponent extends Component {
     } else {
       // not multipleSelect
       this.props.saveSelected({ id, selected: [value] });
-      this.props.toggleOpen({ id, open: false });
+      this.props.toggleOpen({ id, isOpen: false });
     }
   }
 


### PR DESCRIPTION
#### Description

This branch fixes the toggleopen action call after an item has been selected when not using multi select

----
#### Changes

- `open` --> `isOpen`

----
#### Checklist:
- [ ] Tests – Have you added or edited the test cases?
- [x] Rebase – Has this PR been rebased against `master`?
